### PR TITLE
ENH: make Cycler callable to return infinite cycle

### DIFF
--- a/cycler.py
+++ b/cycler.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-from itertools import product
+from itertools import product, cycle
 from six.moves import zip, reduce
 from operator import mul, add
 import copy
@@ -62,6 +62,9 @@ class Cycler(object):
         Function which composes the 'left' and 'right' cyclers.
 
     """
+    def __call__(self):
+        return cycle(self)
+
     def __init__(self, left, right=None, op=None):
         """Semi-private init
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -69,6 +69,16 @@ which returns a new  `Cycler` with a new label, but the same values.
    cycler('ec', color_cycle)
 
 
+Iterating over a `Cycler` results in the finite list of entries, to
+get an infinite cycle, call the `Cycler` object (a-la a generator)
+
+.. ipython:: python
+
+   cc = color_cycle()
+   for j, c in zip(range(5),  cc):
+       print(j, c)
+
+
 Composition
 -----------
 

--- a/test_cycler.py
+++ b/test_cycler.py
@@ -3,8 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 import six
 from six.moves import zip, range
 from cycler import cycler, Cycler
-from nose.tools import assert_equal, assert_raises
-from itertools import product
+from nose.tools import assert_equal, assert_raises, assert_true
+from itertools import product, cycle
 from operator import add, iadd, mul, imul
 
 
@@ -148,3 +148,15 @@ def test_repr():
 
     yield _repr_tester_helper, '_repr_html_', c + c2, sum_html
     yield _repr_tester_helper, '_repr_html_', c * c2, prod_html
+
+
+def test_call():
+    c = cycler('c', 'rgb')
+    c_cycle = c()
+    assert_true(isinstance(c_cycle, cycle))
+    j = 0
+    for a, b in zip(2*c, c_cycle):
+        j += 1
+        assert_equal(a, b)
+
+    assert_equal(j, len(c) * 2)


### PR DESCRIPTION
Following in the tradition of generators and co-routines, to get an infinite cycle call the `Cycler` object.

Closes #2 