### PR TITLE
FIX: don't expose internals to outside world

### DIFF
--- a/cycler.py
+++ b/cycler.py
@@ -129,7 +129,7 @@ class Cycler(object):
 
     def __iter__(self):
         if self._right is None:
-            return iter(self._left)
+            return iter(dict(l) for l in self._left)
 
         return self._compose()
 


### PR DESCRIPTION
Was returning refs to dicts stored in _left at bottom of the stack.
This means any mutation to these objects gets reflected back down into
the cycler with out any of the keys being updated etc.