### PR TITLE
ENH: add concat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: python
 
 matrix:
   include:
-    - python: 2.6
     - python: 2.7
-    - python: 3.3
     - python: 3.4
+    - python: 3.5
     - python: "nightly"
       env: PRE=--pre
   allow_failures:

--- a/cycler.py
+++ b/cycler.py
@@ -390,6 +390,20 @@ class Cycler(object):
         return reduce(add, (_cycler(k, v) for k, v in six.iteritems(trans)))
 
     def concat(self, other):
+        """Concatenate two cyclers.
+
+        The keys must match exactly.
+
+        Parameters
+        ----------
+        other : `Cycler`
+            The `Cycler` instances to concatenate to this one
+
+        Returns
+        -------
+        ret : `Cycler`
+            The concatenated `Cycler`
+        """
         return concat(self, other)
 
 

--- a/cycler.py
+++ b/cycler.py
@@ -389,6 +389,41 @@ class Cycler(object):
         trans = self._transpose()
         return reduce(add, (_cycler(k, v) for k, v in six.iteritems(trans)))
 
+    def concat(self, other):
+        return concat(self, other)
+
+
+def concat(left, right):
+    """Concatenate two cyclers.
+
+    The keys must match exactly.
+
+    This returns a single Cycler which is equivalent to
+    `itertools.chain(left, right)`
+
+    Parameters
+    ----------
+    left, right : `Cycler`
+        The two `Cycler` instances to concatenate
+
+    Returns
+    -------
+    ret : `Cycler`
+        The concatenated `Cycler`
+    """
+    if left.keys != right.keys:
+        msg = '\n\t'.join(["Keys do not match:",
+                            "Intersection: {both!r}",
+                            "Disjoint: {just_one!r}"
+                            ]).format(
+                                both=left.keys&right.keys,
+                                just_one=left.keys^right.keys)
+
+        raise ValueError(msg)
+
+    _l = left._transpose()
+    _r = right._transpose()
+    return reduce(add, (_cycler(k, _l[k] + _r[k]) for k in left.keys))
 
 def cycler(*args, **kwargs):
     """

--- a/cycler.py
+++ b/cycler.py
@@ -415,6 +415,14 @@ def concat(left, right):
     This returns a single Cycler which is equivalent to
     `itertools.chain(left, right)`
 
+    Examples
+    --------
+
+    >>> num = cycler('a', range(3))
+    >>> let = cycler('a', 'abc')
+    >>> num.concat(let)
+    cycler('a', [0, 1, 2, 'a', 'b', 'c'])
+
     Parameters
     ----------
     left, right : `Cycler`

--- a/cycler.py
+++ b/cycler.py
@@ -390,14 +390,25 @@ class Cycler(object):
         return reduce(add, (_cycler(k, v) for k, v in six.iteritems(trans)))
 
     def concat(self, other):
-        """Concatenate two cyclers.
+        """Concatenate this cycler and an other.
 
         The keys must match exactly.
+
+        This returns a single Cycler which is equivalent to
+        `itertools.chain(self, other)`
+
+        Examples
+        --------
+
+        >>> num = cycler('a', range(3))
+        >>> let = cycler('a', 'abc')
+        >>> num.concat(let)
+        cycler('a', [0, 1, 2, 'a', 'b', 'c'])
 
         Parameters
         ----------
         other : `Cycler`
-            The `Cycler` instances to concatenate to this one
+            The `Cycler` to concatenate to this one.
 
         Returns
         -------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -180,6 +180,22 @@ Integer Multiplication
    2 * color_cycle
 
 
+Concatenation
+~~~~~~~~~~~~~
+
+`Cycler` objects can be concatenated either via the :py:meth:`Cycler.concat` method
+
+.. ipython:: python
+
+   color_cycle.concat(color_cycle)
+
+or the top-level :py:func:`concat` function
+
+.. ipython:: python
+
+   from cycler import concat
+   concat(color_cycle, color_cycle)
+
 
 Slicing
 -------

--- a/test_cycler.py
+++ b/test_cycler.py
@@ -283,10 +283,11 @@ def test_starange_init():
 
 def test_concat():
     a = cycler('a', range(3))
-    for con, chn in zip(a.concat(a), chain(a, a)):
+    b = cycler('a', 'abc')
+    for con, chn in zip(a.concat(b), chain(a, b)):
         assert_equal(con, chn)
 
-    for con, chn in zip(concat(a, a), chain(a, a)):
+    for con, chn in zip(concat(a, b), chain(a, b)):
         assert_equal(con, chn)
 
 

--- a/test_cycler.py
+++ b/test_cycler.py
@@ -2,10 +2,10 @@ from __future__ import (absolute_import, division, print_function)
 
 import six
 from six.moves import zip, range
-from cycler import cycler, Cycler
+from cycler import cycler, Cycler, concat
 from nose.tools import (assert_equal, assert_not_equal,
                         assert_raises, assert_true)
-from itertools import product, cycle
+from itertools import product, cycle, chain
 from operator import add, iadd, mul, imul
 
 
@@ -279,3 +279,19 @@ def test_starange_init():
     c2 = cycler('lw', range(3))
     cy = Cycler(list(c), list(c2), zip)
     assert_equal(cy, c + c2)
+
+
+def test_concat():
+    a = cycler('a', range(3))
+    for con, chn in zip(a.concat(a), chain(a, a)):
+        assert_equal(con, chn)
+
+    for con, chn in zip(concat(a, a), chain(a, a)):
+        assert_equal(con, chn)
+
+
+def test_concat_fail():
+    a = cycler('a', range(3))
+    b = cycler('b', range(3))
+    assert_raises(ValueError, concat, a, b)
+    assert_raises(ValueError, a.concat, b)


### PR DESCRIPTION
Adds a top level function `concat` and a `Cycler` method `concat` which
will concatenate two cyclers.  The method can be chained.

closes #1 

I am still partial to using `&` or `|` as the concatenation operator, but I don't think there is enough consensus to implement it.

@OceanWolf @efiring @WeatherGod @pelson 