### PR TITLE
FIX: Do not fail _repr_html_ if keys are unorderable.

### DIFF
--- a/cycler.py
+++ b/cycler.py
@@ -335,7 +335,7 @@ class Cycler(object):
     def _repr_html_(self):
         # an table showing the value of each key through a full cycle
         output = "<table>"
-        sorted_keys = sorted(self.keys)
+        sorted_keys = sorted(self.keys, key=repr)
         for key in sorted_keys:
             output += "<th>{key!r}</th>".format(key=key)
         for d in iter(self):


### PR DESCRIPTION
Cleaning up after my own mistakes...

This example reproduces the bug. It only affects the IPython "rich display" repr, so it is only noticeable in the notebook. IPython currently converts the `TypeError` into a warning, but it would be better if it worked!

```
class A:
    pass

a = A()
b = A()

cycler(a, [1,2]) + cycler(b, [3, 4])
```