### PR TITLE
DOC: Fix typos about itertools.product

### DIFF
--- a/cycler.py
+++ b/cycler.py
@@ -87,7 +87,7 @@ class Cycler(object):
       in-place ``+``
 
     ``*``
-      for outer products (itertools.product) and integer multiplication
+      for outer products (`itertools.product`) and integer multiplication
 
     ``*=``
       in-place ``*``

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -156,7 +156,7 @@ Any pair of `Cycler` can be multiplied
    m_c = m_cycle * color_cycle
 
 which gives the 'outer product' of the two cycles (same as
-:func:`itertools.prod` )
+:func:`itertools.product` )
 
 .. ipython:: python
 


### PR DESCRIPTION
Fix the small typo noticed in #35 . This PR also fixes what seems to be another small typo in one of the docstrings in `cycler.py`, by adding back ticks (\`\`) around "itertools.product".