### PR TITLE
Enh tail

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source=cycler
+branch=True
+[report]
+omit =
+    *test*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ matrix:
 
 install:
   - python setup.py install
-  - pip install coveralls six
+  - pip install pytest pytest-cov coverage six
 
 script:
-  - python run_tests.py
+  - coverage run run_tests.py
+  - coverage report -m
 
 after_success:
-  coveralls
+  - bash <(curl -s https://codecov.io/bash)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Install the build and runtime dependencies of the project.
-  - "%CMD_IN_ENV% pip install -v six nose coveralls"
+  - "%CMD_IN_ENV% pip install -v six nose pytest pytest-cov coverage"
 
   # Install the generated wheel package to test it
   - "python setup.py install"

--- a/cycler.py
+++ b/cycler.py
@@ -558,3 +558,32 @@ def _cycler(label, itr):
         itr = (v[lab] for v in itr)
 
     return Cycler._from_iter(label, itr)
+
+
+def cycler_with_tail(cyl, tail):
+    '''After the cycle is exhausted continue to yield tail
+
+
+    Parameters
+    ----------
+    cyl : Cycler
+       The cycler to iterate through
+
+    tail : dict
+        The dictionary to yield.  Must have the same keys as ``cyl``.
+
+    Yields
+    ------
+    sty : dict
+    '''
+    tk = set(tail.keys())
+    if cyl.keys != tk:
+        raise RuntimeError('The cycler has keys {} and the tail {}.  The '
+                           'different keys are {}'.format(cyl.keys,
+                                                          tk, tk ^ cyl.keys))
+
+    for sty in cyl:
+        yield sty
+
+    while True:
+        yield tail

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -26,12 +26,13 @@ github https://github.com/matplotlib/cycler
    cycler
    Cycler
    concat
+   cycler_with_tail
 
 The public API of :py:mod:`cycler` consists of a class `Cycler`, a
-factory function :func:`cycler`, and a concatenation function
-:func:`concat`.  The factory function provides a simple interface for
-creating 'base' `Cycler` objects while the class takes care of the
-composition and iteration logic.
+factory function :func:`cycler`, a concatenation function
+:func:`concat`, and a few helper functions.  The factory function
+provides a simple interface for creating 'base' `Cycler` objects while
+the class takes care of the composition and iteration logic.
 
 
 `Cycler` Usage

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,27 +1,11 @@
 #!/usr/bin/env python
-# This file is closely based on tests.py from matplotlib
-#
-# This allows running the matplotlib tests from the command line: e.g.
-#
-#   $ python run_tests.py -v -d
-#
-# The arguments are identical to the arguments accepted by nosetests.
-#
-# See https://nose.readthedocs.org/ for a detailed description of
-# these options.
-import nose
-
-
-env = {"NOSE_WITH_COVERAGE": 1,
-       'NOSE_COVER_PACKAGE': ['cycler'],
-       'NOSE_COVER_HTML': 1}
-plugins = []
-
-
-def run():
-
-    nose.main(addplugins=[x() for x in plugins], env=env)
-
+import sys
+import pytest
 
 if __name__ == '__main__':
-    run()
+    # show output results from every test function
+    args = []
+    args.extend(sys.argv[1:])
+    # call pytest and exit with the return code from pytest so that
+    # travis will fail correctly if tests fail
+    sys.exit(pytest.main(args))

--- a/test_cycler.py
+++ b/test_cycler.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import six
 from six.moves import zip, range
-from cycler import cycler, Cycler, concat
+from cycler import cycler, Cycler, concat, cycler_with_tail
 import pytest
 from itertools import product, cycle, chain
 from operator import add, iadd, mul, imul
@@ -341,3 +341,18 @@ def test_contains():
 
     assert 'a' in ab
     assert 'b' in ab
+
+
+def test_tail():
+    a = cycler('a', range(3))
+    tail = {'a': 4}
+
+    cy_with_tail = cycler_with_tail(a, tail)
+    for j in range(3):
+        next(cy_with_tail)
+
+    for j in range(5):
+        assert {'a': 4} == next(cy_with_tail)
+
+    with pytest.raises(RuntimeError):
+        next(cycler_with_tail(a, {'b': 1}))


### PR DESCRIPTION
Only look at the second commit.

This is mostly for discussion.  As with #38 this is a useful function, but not sure it is useful enough / has a 'correct' enough API to be worth shipping with the package and they can instead (continue to) live as examples in the documentation (as with https://docs.python.org/3.5/library/itertools.html#itertools-recipes)