### PR TITLE
DOC: update documentation build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,7 +36,6 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
-    'matplotlib.sphinxext.only_directives',
     'matplotlib.sphinxext.plot_directive',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,7 +46,7 @@ extensions = [
 autosummary_generate = True
 
 numpydoc_show_class_members = False
-autodoc_default_flags = ['members']
+autodoc_default_options = {'members': True}
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,7 +4,7 @@
  Composable cycles
 ===================
 
-.. htmlonly::
+.. only:: html
 
     :Version: |version|
     :Date: |today|

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -50,7 +50,6 @@ hashable (as it will eventually be used as the key in a :obj:`dict`).
    from __future__ import print_function
    from cycler import cycler
 
-
    color_cycle = cycler(color=['r', 'g', 'b'])
    color_cycle
 


### PR DESCRIPTION
Closes #55

Tried only removing 1 blank line (which is else where in the file) to
keep the visual break.

Also updated:
 - in mpl3.0 Matplotlib deprecated the htmlonly directive
 - update sphinx config account for sphinx1.8 configuration
   deprecation