### PR TITLE
CI: Update to codecov-action@v2, Python 3.10-dev to 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,4 +42,4 @@ jobs:
           pytest -raR -n auto --cov --cov-report=
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
On February 1, 2022, the codecov-action v1 will be end of life and not longer function. See https://github.com/codecov/codecov-action/tree/v2.1.0#%EF%B8%8F--deprecration-of-v1. This commit updates the action to v2.

Also, the Python 3.10-dev tag is replaced with 3.10 since it's in stable release now.