### PR TITLE
[ENH] Update error message printed on overlapping cycles to be more verbose

### DIFF
--- a/cycler/__init__.py
+++ b/cycler/__init__.py
@@ -81,8 +81,8 @@ def _process_keys(
     r_peek: dict[K, V] = next(iter(right)) if right is not None else {}
     l_key: set[K] = set(l_peek.keys())
     r_key: set[K] = set(r_peek.keys())
-    if l_key & r_key:
-        raise ValueError(f"Cannot compose overlapping cycles, duplicate key(s): {l_key & r_key}")
+    if common_keys := l_key & r_key:
+        raise ValueError(f"Cannot compose overlapping cycles, duplicate key(s): {common_keys}")
 
     return l_key | r_key
 

--- a/cycler/__init__.py
+++ b/cycler/__init__.py
@@ -82,7 +82,9 @@ def _process_keys(
     l_key: set[K] = set(l_peek.keys())
     r_key: set[K] = set(r_peek.keys())
     if common_keys := l_key & r_key:
-        raise ValueError(f"Cannot compose overlapping cycles, duplicate key(s): {common_keys}")
+        raise ValueError(
+            f"Cannot compose overlapping cycles, duplicate key(s): {common_keys}"
+        )
 
     return l_key | r_key
 

--- a/cycler/__init__.py
+++ b/cycler/__init__.py
@@ -82,7 +82,8 @@ def _process_keys(
     l_key: set[K] = set(l_peek.keys())
     r_key: set[K] = set(r_peek.keys())
     if l_key & r_key:
-        raise ValueError("Can not compose overlapping cycles")
+        raise ValueError(f"Cannot compose overlapping cycles, duplicate key(s): {l_key & r_key}")
+
     return l_key | r_key
 
 


### PR DESCRIPTION
The error message will now print out which keys were duplicated. Addresses https://github.com/bluesky/bluesky/issues/1768

Example output:

```
...
...
  File "/home/jwlodek/Workspace/cycler/cycler/__init__.py", line 288, in __add__
    return Cycler(
           ^^^^^^^
  File "/home/jwlodek/Workspace/cycler/cycler/__init__.py", line 181, in __init__
    self._keys: set[K] = _process_keys(self._left, self._right)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jwlodek/Workspace/cycler/cycler/__init__.py", line 85, in _process_keys
    raise ValueError(f"Cannot compose overlapping cycles, duplicate key(s): {l_key & r_key}")
ValueError: Cannot compose overlapping cycles, duplicate key(s): {SoftPositioner(name='my_positioner1', settle_time=0.0, timeout=None, egu='', limits=(0, 0), source='computed')}
```