### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set up reviewdog
         if: "${{ steps.fetch-artifacts.outputs.count != 0 }}"
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1
         with:
           reviewdog_version: latest
 

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Set up reviewdog
         if: "${{ steps.fetch-artifacts.outputs.count != 0 }}"
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
         with:
           reviewdog_version: latest
 

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -27,11 +27,15 @@ jobs:
     name: Post warnings/errors as review
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Fetch result artifacts
         id: fetch-artifacts
         run: |
-          python .circleci/fetch_doc_logs.py "${{ github.event.target_url }}"
+          python .circleci/fetch_doc_logs.py "${GITHUB_EVENT_TARGET_URL}"
+        env:
+          GITHUB_EVENT_TARGET_URL: ${{ github.event.target_url }}
 
       - name: Set up reviewdog
         if: "${{ steps.fetch-artifacts.outputs.count != 0 }}"

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
-        uses: larsoner/circleci-artifacts-redirector-action@master
+        uses: scientific-python/circleci-artifacts-redirector-action@7eafdb60666f57706a5525a2f5eb76224dc8779b  # v1.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/doc/build/html/index.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 ---
 
 name: Release
+permissions:
+  contents: read
 on:
   release:
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
+          persist-credentials: false
 
       - name: Set up Python
         id: setup

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,7 @@
 ---
 name: Linting
+permissions:
+  contents: read
 on:
   push:
     branches-ignore:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3
         uses: actions/setup-python@v4
@@ -47,6 +49,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 ---
 
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,4 +45,4 @@ jobs:
           pytest -raR -n auto --cov --cov-report=
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,4 @@ jobs:
           pytest -raR -n auto --cov --cov-report=
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
